### PR TITLE
Accept arbitrary-length CVE IDs

### DIFF
--- a/lib/lita/handlers/onewheel_cve.rb
+++ b/lib/lita/handlers/onewheel_cve.rb
@@ -4,7 +4,7 @@ module Lita
       config :search_url, default: 'http://www.cve.mitre.org/cgi-bin/cvename.cgi?name='
 
       route(
-        /(\s|^)cve-(?<id>\d{4}-\d{4})/i,
+        /(\s|^)cve-(?<id>\d{4}-\d+)/i,
         :handle_cve,
         help: {
           'text including cve-1234-1234' => 'Will return a link to cve.mitre.org.'

--- a/spec/lita/handlers/onewheel_cve_spec.rb
+++ b/spec/lita/handlers/onewheel_cve_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Lita::Handlers::OnewheelCve, lita_handler: true do
   it { is_expected.to route('  cve-2015-1234  ').to(:handle_cve) }
+  it { is_expected.to route('  cve-2015-1234567  ').to(:handle_cve) }
   it { is_expected.to_not route('  cve-12-12  ').to(:handle_cve) }
   it { is_expected.to_not route('http://example.com/cve-2015-1234').to(:handle_cve) }
 


### PR DESCRIPTION
Per https://cve.mitre.org/cve/identifiers/syntaxchange.html:

> The new CVE ID syntax is variable length and includes:
>
>  CVE prefix + Year + Arbitrary Digits
>
> There is no limit on the number of arbitrary digits."