### PR TITLE
[SDV-928] bundler version for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,44 @@
+version: 2.1
+
+merge_master: &merge_master
+  name: Fetch PR merge commit
+  command: |
+    # Merges master into our PR and fails if we have a conflict on that
+    if [[ -n "${CIRCLE_PULL_REQUEST}" ]]; then
+      git fetch origin master
+      git config --global user.email "circleci@pagerduty.com"
+      git config --global user.name "circleci"
+
+      git rebase origin/master
+      if [[ $? -ne 0 ]]; then
+        echo "Merge conflict detected; aborting. Please manually fix the conflict and retry."
+        exit 1
+      fi
+    fi
+
+jobs:
+  test:
+    docker:
+      - image: circleci/ruby:2.7.3
+        environment:
+          LANG: en_US.UTF-8
+          LANGUAGE: en_US:en
+          LC_ALL: en_US.UTF-8
+      - image: circleci/redis:latest
+    steps:
+      - checkout
+      - run:
+          <<: *merge_master
+      - run:
+          name: 'install dependencies'
+          command: bundle install
+      - run:
+          name: 'run tests'
+          command: bundle exec rspec
+
+workflows:
+  version: 2
+  test_and_publish:
+    jobs:
+      - test:
+          context: PagerDuty

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: ruby
-rvm:
-  - 2.2
-  - 2.3.0
-services:
-  - redis-server
-cache: bundler

--- a/lita-onewheel-cve.gemspec
+++ b/lita-onewheel-cve.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'lita', '~> 4'
 
-  spec.add_development_dependency 'bundler', '~> 1.3'
+  spec.add_development_dependency 'bundler', '~> 2.1'
   spec.add_development_dependency 'coveralls', '~> 0.8'
   # spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rake', '~> 10.4'


### PR DESCRIPTION
## Context
During my onboarding, I worked on upgrading the dependencies for officerurl. At the time, I noticed that some lita plugins repo had unit tests, but we did not configure any CI to run them.

So, just a quick change to configure circleci to run the unit tests on these repos.

## References
[SDV-928](https://pagerduty.atlassian.net/browse/SDV-928)